### PR TITLE
Ensure code is linted on Travis prior to publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,22 @@
 language: node_js
 node_js:
-  - '8'
-  - '10'
+  - "10"
 
-cache:
-  directories:
-    - 'node_modules'
+cache: npm
 
-if: tag IS blank
+if: branch = master
 
-jobs:
-  include:
-    - stage: npm release
+script: npm run lint
 
-      if: branch = master
+before_deploy:
+  - export VERSION_TAG=$(git ls-remote origin | grep "$TRAVIS_COMMIT\s\+refs/tags/v[0-9]\+\.[0-9]\+\.[0-9]\+\^{}$")
+  - echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+  - npm i --global otp-cli
+  - export NPM_OTP=$(otp-cli totp generate -k "$NPM_OTP_SECRET")
 
-      script: echo publishing...
+deploy:
+  provider: script
+  script: if [ -n "$VERSION_TAG" ]; then npm publish --access public --otp "$NPM_OTP"; else echo commit not tagged; fi
+  skip_cleanup: true
 
-      before_deploy:
-        - export VERSION_TAG=$(git ls-remote origin | grep "$TRAVIS_COMMIT\s\+refs/tags/v[0-9]\+\.[0-9]\+\.[0-9]\+\^{}$")
-        - echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
-        - npm i --global otp-cli
-        - export NPM_OTP=$(otp-cli totp generate -k "$NPM_OTP_SECRET")
-      deploy:
-        provider: script
-        script: if [ -n "$VERSION_TAG" ]; then npm publish --access public --otp "$NPM_OTP"; else echo commit not tagged; fi
-        skip_cleanup: true
-      after_deploy: rm ~/.npmrc
+after_deploy: rm ~/.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -357,6 +357,12 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -1945,6 +1951,17 @@
         }
       }
     },
+    "eslint-plugin-require-path-exists": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-require-path-exists/-/eslint-plugin-require-path-exists-1.1.9.tgz",
+      "integrity": "sha512-moZRfrPr4GFyT/W8PHzjzC7D4Hnj7Us+GYj0fbVKQoPvP4xIF8VG702L1jzyhqE8eIYkcs8p1CoqSfjk9WkxBg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.1.1",
+        "fs-plus": "^3.0.0",
+        "resolve": "^1.1.7"
+      }
+    },
     "eslint-plugin-standard": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
@@ -2285,6 +2302,18 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "fs-plus": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.1.1.tgz",
+      "integrity": "sha512-Se2PJdOWXqos1qVTkvqqjb0CSnfBnwwD+pq+z4ksT+e97mEShod/hrNg0TRCCsXPbJzcIq+NuzQhigunMWMJUA==",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2",
+        "underscore-plus": "1.x"
       }
     },
     "fs.realpath": {
@@ -5617,6 +5646,21 @@
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
+      }
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+      "dev": true
+    },
+    "underscore-plus": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.7.0.tgz",
+      "integrity": "sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==",
+      "dev": true,
+      "requires": {
+        "underscore": "^1.9.1"
       }
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-prefer-arrow": "^1.1.3",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.10.0",
+    "eslint-plugin-require-path-exists": "^1.1.9",
     "eslint-plugin-standard": "^4.0.0",
     "husky": "^1.3.0",
     "lint-staged": "^8.1.3",


### PR DESCRIPTION
Travis fail to publish because a dep was missing and preventing linting before the execution of `npm publish`. Adding the dep and updating `.travis.yml` so code is linted on each commit, prevents this to happen again.

In addition, since there is only one version of Node (LTS 10) that will be used to lint and publish, the configuration of Travis can be simplified.